### PR TITLE
feat: override user agent for databend-go client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/databendlabs/grafana-databend-datasource
 go 1.25.7
 
 require (
-	github.com/datafuselabs/databend-go v0.9.2
+	github.com/datafuselabs/databend-go v0.9.3
 	github.com/grafana/grafana-plugin-sdk-go v0.292.0
 	github.com/grafana/sqlds/v4 v4.1.3
 	github.com/magefile/mage v1.17.2

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/clipperhouse/uax29/v2 v2.6.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsV
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/datafuselabs/databend-go v0.9.2 h1:J5Nk1Q/9sjX3HX0RC4mUpHJ/JLsu2NqZq6tXkhRsSbg=
-github.com/datafuselabs/databend-go v0.9.2/go.mod h1:G90oi9bpPFdwpBeRW1DNBYjLsEtzFVq8R5nZCPqNn1Q=
+github.com/datafuselabs/databend-go v0.9.3 h1:oPKOZcGQPpIQ5246ymPrmDn7AzRXWo8ADMoQ1Nu5gbU=
+github.com/datafuselabs/databend-go v0.9.3/go.mod h1:4gZSxuLaYCITyrPz5I9VI0gLwf2KHIasfhedYDpmb10=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-databend",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Grafana datasource plugin for Databend",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"net/url"
 
-	_ "github.com/datafuselabs/databend-go"
+	godatabend "github.com/datafuselabs/databend-go"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
@@ -15,6 +15,8 @@ import (
 	"github.com/databendlabs/grafana-databend-datasource/pkg/converters"
 	"github.com/databendlabs/grafana-databend-datasource/pkg/macros"
 )
+
+const userAgent = "grafana-databend-datasource"
 
 // Databend defines how to connect to a Databend datasource
 type Databend struct{}
@@ -37,7 +39,12 @@ func (d *Databend) Connect(ctx context.Context, config backend.DataSourceInstanc
 	} else {
 		dsn = settings.DSN
 	}
-	return sql.Open("databend", dsn)
+	cfg, err := godatabend.ParseDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+	cfg.UserAgent = userAgent
+	return sql.OpenDB(cfg), nil
 }
 
 // Converters defines list of data type converters


### PR DESCRIPTION
Set custom `UserAgent` on databend-go `Config` so all HTTP requests to Databend include `grafana-databend-datasource` in the User-Agent header.

Changes:
- Use `godatabend.ParseDSN` + `sql.OpenDB` instead of `sql.Open`
- Set `cfg.UserAgent = "grafana-databend-datasource"`
- Bump databend-go to v0.9.3
- Bump version to 1.2.1