### PR TITLE
fix(backend): sort time series frames by time ascending

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-databend",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Grafana datasource plugin for Databend",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"net/url"
+	"sort"
+	"time"
 
 	godatabend "github.com/datafuselabs/databend-go"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -69,10 +71,16 @@ func (d *Databend) Settings(ctx context.Context, config backend.DataSourceInstan
 }
 
 // MutateResponse implements sqlds.ResponseMutator.
-// It post-processes query result frames (e.g., converting JSON fields to strings for non-log/trace visualizations).
+// It post-processes query result frames (e.g., sorting by time, converting JSON fields to strings).
 func (d *Databend) MutateResponse(_ context.Context, res data.Frames) (data.Frames, error) {
 	for _, frame := range res {
-		if frame == nil || frame.Meta == nil {
+		if frame == nil {
+			continue
+		}
+		// Sort frame rows by the first time field in ascending order
+		sortFrameByTime(frame)
+
+		if frame.Meta == nil {
 			continue
 		}
 		// For non-logs/traces/table visualizations, convert JSON fields to string
@@ -81,6 +89,87 @@ func (d *Databend) MutateResponse(_ context.Context, res data.Frames) (data.Fram
 		}
 	}
 	return res, nil
+}
+
+// sortFrameByTime sorts all rows in the frame by the first time field in ascending order.
+// Grafana requires time series data to be sorted ascending by time.
+func sortFrameByTime(frame *data.Frame) {
+	if frame == nil || len(frame.Fields) == 0 {
+		return
+	}
+
+	// Find the first time field
+	timeFieldIdx := -1
+	for i, field := range frame.Fields {
+		if field.Type() == data.FieldTypeTime || field.Type() == data.FieldTypeNullableTime {
+			timeFieldIdx = i
+			break
+		}
+	}
+	if timeFieldIdx < 0 {
+		return
+	}
+
+	rowLen := frame.Fields[timeFieldIdx].Len()
+	if rowLen <= 1 {
+		return
+	}
+
+	// Build index slice and sort by time
+	indices := make([]int, rowLen)
+	for i := range indices {
+		indices[i] = i
+	}
+
+	timeField := frame.Fields[timeFieldIdx]
+	sort.SliceStable(indices, func(i, j int) bool {
+		ti := getTimeValue(timeField, indices[i])
+		tj := getTimeValue(timeField, indices[j])
+		return ti.Before(tj)
+	})
+
+	// Check if already sorted
+	sorted := true
+	for i, idx := range indices {
+		if i != idx {
+			sorted = false
+			break
+		}
+	}
+	if sorted {
+		return
+	}
+
+	// Reorder all fields according to sorted indices
+	for fi, field := range frame.Fields {
+		newField := data.NewFieldFromFieldType(field.Type(), rowLen)
+		newField.Name = field.Name
+		newField.Labels = field.Labels
+		newField.Config = field.Config
+		for i, idx := range indices {
+			newField.Set(i, field.At(idx))
+		}
+		frame.Fields[fi] = newField
+	}
+}
+
+// getTimeValue extracts a time.Time from a field at the given index, handling nullable types.
+func getTimeValue(field *data.Field, idx int) time.Time {
+	val := field.At(idx)
+	if val == nil {
+		return time.Time{}
+	}
+	switch v := val.(type) {
+	case time.Time:
+		return v
+	case *time.Time:
+		if v == nil {
+			return time.Time{}
+		}
+		return *v
+	default:
+		return time.Time{}
+	}
 }
 
 // shouldConvertJSONFields returns true if JSON fields should be converted to string for the given visualization type.


### PR DESCRIPTION
## Summary

Grafana requires time series data to be sorted in ascending order by time. When queries return data without explicit `ORDER BY`, the frontend reports:

> unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time if possible

## Changes

- Add `sortFrameByTime` in `MutateResponse` to ensure all frames with a time field are sorted ascending before being sent to the frontend
- Handles both `FieldTypeTime` and `FieldTypeNullableTime`
- Uses `sort.SliceStable` to preserve original order for equal timestamps
- Skips sorting if data is already in order (no unnecessary allocations)
- Bump version to 1.2.2