### PR TITLE
feat(query): flesh out logs/traces builder and ad-hoc filter support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-databend",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Grafana datasource plugin for Databend",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -101,6 +101,16 @@ export const ConfigEditor: React.FC<Props> = (props) => {
             onChange={(e) => onJsonDataChange('forwardGrafanaHeaders', e.currentTarget.checked)}
           />
         </Field>
+        <Field label="Default Ad-Hoc Filter Table" description="Default table for ad-hoc filter tag keys/values">
+          <Input
+            name="defaultAdHocTable"
+            width={40}
+            value={jsonData.defaultAdHocTable || ''}
+            onChange={onUpdateDatasourceJsonDataOption(props, 'defaultAdHocTable')}
+            aria-label="Default Ad-Hoc Filter Table"
+            placeholder="my_table"
+          />
+        </Field>
       </ConfigSection>
 
       <Divider />
@@ -145,6 +155,14 @@ export const ConfigEditor: React.FC<Props> = (props) => {
               onChange={onUpdateDatasourceJsonDataOption(props, 'logsMessageColumn')}
               aria-label="Log Message Column"
               placeholder="body"
+            />
+          </Field>
+        </ConfigSubSection>
+        <ConfigSubSection title="Data Links">
+          <Field label="Show Trace Links" description="Show clickable trace links on TraceId fields in log query results">
+            <Switch
+              value={jsonData.showLogLinks !== false}
+              onChange={(e) => onJsonDataChange('showLogLinks', e.currentTarget.checked)}
             />
           </Field>
         </ConfigSubSection>
@@ -232,6 +250,14 @@ export const ConfigEditor: React.FC<Props> = (props) => {
               onChange={onUpdateDatasourceJsonDataOption(props, 'tracesStartTimeColumn')}
               aria-label="Start Time Column"
               placeholder="timestamp"
+            />
+          </Field>
+        </ConfigSubSection>
+        <ConfigSubSection title="Data Links">
+          <Field label="Show Trace Links" description="Show clickable trace visualization links on TraceId fields">
+            <Switch
+              value={jsonData.showTraceLinks !== false}
+              onChange={(e) => onJsonDataChange('showTraceLinks', e.currentTarget.checked)}
             />
           </Field>
         </ConfigSubSection>

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -4,7 +4,7 @@ import { InlineField, InlineFieldRow, RadioButtonGroup, Select } from '@grafana/
 import { DatabendDatasource } from '../data/datasource';
 import { DatabendConfig } from '../types/config';
 import { DatabendQuery, EditorType, QueryType, defaultDatabendQuery, queryTypeToFormat } from '../types/sql';
-import { BuilderMode, QueryBuilderOptions } from '../types/queryBuilder';
+import { BuilderMode, ColumnHint, QueryBuilderOptions, SelectedColumn } from '../types/queryBuilder';
 import { generateSql } from '../data/sqlGenerator';
 import { SqlEditor } from './SqlEditor';
 import { QueryBuilder } from './queryBuilder/QueryBuilder';
@@ -44,13 +44,13 @@ export const QueryEditor: React.FC<Props> = (props) => {
   } as DatabendQuery;
 
   const editorType = currentQuery.editorType || EditorType.SQL;
-  const queryType = (currentQuery as any).queryType || QueryType.Table;
+  const queryType = currentQuery.queryType || QueryType.Table;
 
   const builderOptions: QueryBuilderOptions = useMemo(() => {
     if (currentQuery.editorType === EditorType.Builder) {
-      return (currentQuery as any).builderOptions || defaultBuilderOptions;
+      return currentQuery.builderOptions || defaultBuilderOptions;
     }
-    return (currentQuery as any).meta?.builderOptions || defaultBuilderOptions;
+    return currentQuery.meta?.builderOptions || defaultBuilderOptions;
   }, [currentQuery]);
 
   const generatedSql = useMemo(() => generateSql(builderOptions), [builderOptions]);
@@ -67,7 +67,10 @@ export const QueryEditor: React.FC<Props> = (props) => {
       onChange({
         ...currentQuery,
         editorType: EditorType.SQL,
-        meta: { ...(currentQuery as any).meta, builderOptions },
+        meta: {
+          ...(currentQuery.editorType === EditorType.SQL ? currentQuery.meta : undefined),
+          builderOptions,
+        },
       } as DatabendQuery);
     }
     onRunQuery();
@@ -75,11 +78,34 @@ export const QueryEditor: React.FC<Props> = (props) => {
 
   const onQueryTypeChange = (value: SelectableValue<QueryType>) => {
     const newQueryType = value.value || QueryType.Table;
-    onChange({
-      ...currentQuery,
+
+    // Re-hydrate builder options when switching query type in Builder mode
+    const nextBuilderOptions: QueryBuilderOptions = {
+      ...builderOptions,
       queryType: newQueryType,
-      format: queryTypeToFormat(newQueryType),
-    } as DatabendQuery);
+      columns: applyHintsForQueryType(builderOptions.columns, newQueryType, datasource),
+    };
+
+    if (currentQuery.editorType === EditorType.Builder) {
+      const newSql = generateSql(nextBuilderOptions);
+      onChange({
+        ...currentQuery,
+        queryType: newQueryType,
+        format: queryTypeToFormat(newQueryType),
+        builderOptions: nextBuilderOptions,
+        rawSql: newSql,
+      } as DatabendQuery);
+    } else {
+      onChange({
+        ...currentQuery,
+        queryType: newQueryType,
+        format: queryTypeToFormat(newQueryType),
+        meta: {
+          ...(currentQuery.editorType === EditorType.SQL ? currentQuery.meta : undefined),
+          builderOptions: nextBuilderOptions,
+        },
+      } as DatabendQuery);
+    }
     onRunQuery();
   };
 
@@ -89,12 +115,18 @@ export const QueryEditor: React.FC<Props> = (props) => {
   };
 
   const onBuilderOptionsChange = (newOptions: QueryBuilderOptions) => {
-    const newSql = generateSql(newOptions);
-    const builderQueryType = newOptions.queryType as unknown as QueryType || QueryType.Table;
+    // Keep builderOptions.queryType aligned with the editor queryType
+    const mergedOptions: QueryBuilderOptions = {
+      ...newOptions,
+      queryType: newOptions.queryType || queryType,
+    };
+    const newSql = generateSql(mergedOptions);
+    const builderQueryType = (mergedOptions.queryType as unknown as QueryType) || QueryType.Table;
     onChange({
       ...currentQuery,
       editorType: EditorType.Builder,
-      builderOptions: newOptions,
+      queryType: builderQueryType,
+      builderOptions: mergedOptions,
       rawSql: newSql,
       format: queryTypeToFormat(builderQueryType),
     } as DatabendQuery);
@@ -139,8 +171,58 @@ export const QueryEditor: React.FC<Props> = (props) => {
           builderOptions={builderOptions}
           onBuilderOptionsChange={onBuilderOptionsChange}
           generatedSql={generatedSql}
+          queryType={queryType}
         />
       )}
     </>
   );
 };
+
+/**
+ * Apply default column hints for the chosen query type based on datasource
+ * schema settings (logs/traces columns). Preserves user-picked columns.
+ */
+function applyHintsForQueryType(
+  columns: SelectedColumn[],
+  queryType: QueryType,
+  datasource: DatabendDatasource
+): SelectedColumn[] {
+  const jsonData = datasource.settings.jsonData;
+  const hintMap = new Map<string, ColumnHint>();
+
+  if (queryType === QueryType.Logs) {
+    if (jsonData.logsTimeColumn) hintMap.set(jsonData.logsTimeColumn, ColumnHint.Time);
+    if (jsonData.logsLevelColumn) hintMap.set(jsonData.logsLevelColumn, ColumnHint.LogLevel);
+    if (jsonData.logsMessageColumn) hintMap.set(jsonData.logsMessageColumn, ColumnHint.LogMessage);
+  } else if (queryType === QueryType.Traces) {
+    if (jsonData.tracesStartTimeColumn) hintMap.set(jsonData.tracesStartTimeColumn, ColumnHint.Time);
+    if (jsonData.tracesTraceIdColumn) hintMap.set(jsonData.tracesTraceIdColumn, ColumnHint.TraceId);
+    if (jsonData.tracesSpanIdColumn) hintMap.set(jsonData.tracesSpanIdColumn, ColumnHint.TraceSpanId);
+    if (jsonData.tracesOperationNameColumn)
+      hintMap.set(jsonData.tracesOperationNameColumn, ColumnHint.TraceOperationName);
+    if (jsonData.tracesServiceNameColumn)
+      hintMap.set(jsonData.tracesServiceNameColumn, ColumnHint.TraceServiceName);
+    if (jsonData.tracesDurationColumn)
+      hintMap.set(jsonData.tracesDurationColumn, ColumnHint.TraceDurationTime);
+  } else if (queryType === QueryType.TimeSeries) {
+    // For time series, only set a time hint if we know a sensible default
+    if (jsonData.logsTimeColumn) hintMap.set(jsonData.logsTimeColumn, ColumnHint.Time);
+  }
+
+  const existingNames = new Set(columns.map((c) => c.name));
+  const nextColumns: SelectedColumn[] = columns.map((c) => {
+    const hint = hintMap.get(c.name);
+    return hint ? { ...c, hint } : c;
+  });
+
+  // For logs/traces, prepend any missing hint columns so the builder has the shape it needs.
+  if (queryType === QueryType.Logs || queryType === QueryType.Traces) {
+    for (const [name, hint] of hintMap) {
+      if (!existingNames.has(name)) {
+        nextColumns.push({ name, hint });
+      }
+    }
+  }
+
+  return nextColumns;
+}

--- a/src/components/SqlEditor.tsx
+++ b/src/components/SqlEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from 'react';
 import { CodeEditor, IconButton, HorizontalGroup, Tooltip, Icon } from '@grafana/ui';
-import { DatabendQuery, QueryType } from '../types/sql';
+import { DatabendQuery, DatabendSqlQuery, EditorType, QueryType } from '../types/sql';
 import { styles } from '../styles';
 
 interface SqlEditorProps {
@@ -11,9 +11,11 @@ interface SqlEditorProps {
   onQueryTypeChange?: (queryType: QueryType) => void;
 }
 
-export const SqlEditor: React.FC<SqlEditorProps> = ({ query, onChange, onRunQuery, queryType, onQueryTypeChange }) => {
+export const SqlEditor: React.FC<SqlEditorProps> = ({ query, onChange, onRunQuery }) => {
   const editorRef = useRef<any>(null);
-  const [expanded, setExpanded] = useState<boolean>((query as any).expand || false);
+  const isSqlQuery = query.editorType === EditorType.SQL;
+  const initialExpand = isSqlQuery ? Boolean((query as DatabendSqlQuery).expand) : false;
+  const [expanded, setExpanded] = useState<boolean>(initialExpand);
 
   const saveChanges = (changes: Partial<DatabendQuery>) => {
     onChange({
@@ -50,7 +52,9 @@ export const SqlEditor: React.FC<SqlEditorProps> = ({ query, onChange, onRunQuer
         <a
           onClick={() => {
             setExpanded(!expanded);
-            saveChanges({ expand: !expanded } as any);
+            if (isSqlQuery) {
+              saveChanges({ expand: !expanded } as Partial<DatabendSqlQuery>);
+            }
           }}
           className={styles.Common.expand}
           data-testid="code-editor-expand-button"

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { SelectableValue } from '@grafana/data';
 import { Select, MultiSelect, InlineField, InlineFieldRow, Input, Button, CodeEditor } from '@grafana/ui';
 import { DatabendDatasource } from '../../data/datasource';
+import { QueryType } from '../../types/sql';
 import {
   QueryBuilderOptions,
   BuilderMode,
@@ -12,6 +13,7 @@ import {
   OrderByDirection,
   AggregateColumn,
   AggregateType,
+  ColumnHint,
 } from '../../types/queryBuilder';
 
 interface QueryBuilderProps {
@@ -19,6 +21,7 @@ interface QueryBuilderProps {
   builderOptions: QueryBuilderOptions;
   onBuilderOptionsChange: (options: QueryBuilderOptions) => void;
   generatedSql: string;
+  queryType?: QueryType;
 }
 
 export const QueryBuilder: React.FC<QueryBuilderProps> = ({
@@ -26,6 +29,7 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
   builderOptions,
   onBuilderOptionsChange,
   generatedSql,
+  queryType,
 }) => {
   const [databases, setDatabases] = useState<string[]>([]);
   const [tables, setTables] = useState<string[]>([]);
@@ -70,8 +74,27 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
   };
 
   const onColumnsChange = (values: Array<SelectableValue<string>>) => {
-    const selected: SelectedColumn[] = values.map(v => ({ name: v.value || '' }));
+    const existingHints = new Map(builderOptions.columns.map((c) => [c.name, c.hint] as const));
+    const selected: SelectedColumn[] = values.map((v) => {
+      const name = v.value || '';
+      const hint = existingHints.get(name);
+      return hint ? { name, hint } : { name };
+    });
     onBuilderOptionsChange({ ...builderOptions, columns: selected });
+  };
+
+  const onColumnHintChange = (columnName: string, hint?: ColumnHint) => {
+    const nextColumns = builderOptions.columns.map((c) => {
+      if (c.name !== columnName) {
+        return c;
+      }
+      if (!hint) {
+        const { hint: _discarded, ...rest } = c;
+        return rest;
+      }
+      return { ...c, hint };
+    });
+    onBuilderOptionsChange({ ...builderOptions, columns: nextColumns });
   };
 
   const onGroupByChange = (values: Array<SelectableValue<string>>) => {
@@ -165,6 +188,29 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
     { label: 'NOT IN', value: FilterOperator.NotIn },
   ];
 
+  const hintOptionsForQueryType = (qt?: QueryType): Array<SelectableValue<ColumnHint>> => {
+    if (qt === QueryType.Logs) {
+      return [
+        { label: 'Time', value: ColumnHint.Time },
+        { label: 'Log Level', value: ColumnHint.LogLevel },
+        { label: 'Log Message', value: ColumnHint.LogMessage },
+        { label: 'Trace ID', value: ColumnHint.TraceId },
+      ];
+    }
+    if (qt === QueryType.Traces) {
+      return [
+        { label: 'Start Time', value: ColumnHint.Time },
+        { label: 'Trace ID', value: ColumnHint.TraceId },
+        { label: 'Span ID', value: ColumnHint.TraceSpanId },
+        { label: 'Parent Span ID', value: ColumnHint.TraceParentSpanId },
+        { label: 'Service Name', value: ColumnHint.TraceServiceName },
+        { label: 'Operation Name', value: ColumnHint.TraceOperationName },
+        { label: 'Duration', value: ColumnHint.TraceDurationTime },
+      ];
+    }
+    return [{ label: 'Time', value: ColumnHint.Time }];
+  };
+
   return (
     <div data-testid="query-builder">
       {/* Database & Table Selection */}
@@ -217,6 +263,32 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
           </InlineField>
         </InlineFieldRow>
       )}
+
+      {/* Column hints (Logs / Traces only) */}
+      {builderOptions.mode === BuilderMode.List &&
+        (queryType === QueryType.Logs || queryType === QueryType.Traces) &&
+        builderOptions.columns.length > 0 && (
+          <>
+            {builderOptions.columns.map((col, i) => (
+              <InlineFieldRow key={`hint-${col.name}-${i}`}>
+                <InlineField label={i === 0 ? 'Hints' : ''} labelWidth={14}>
+                  <Input width={25} value={col.name} readOnly aria-label="Hint Column" />
+                </InlineField>
+                <InlineField label="Role" labelWidth={8}>
+                  <Select
+                    width={25}
+                    options={hintOptionsForQueryType(queryType)}
+                    value={col.hint}
+                    onChange={(v) => onColumnHintChange(col.name, v.value ?? undefined)}
+                    isClearable
+                    placeholder="no hint"
+                    aria-label="Column Hint"
+                  />
+                </InlineField>
+              </InlineFieldRow>
+            ))}
+          </>
+        )}
 
       {/* Aggregates (Aggregate/Trend mode) */}
       {(builderOptions.mode === BuilderMode.Aggregate || builderOptions.mode === BuilderMode.Trend) && (

--- a/src/data/datasource.ts
+++ b/src/data/datasource.ts
@@ -4,21 +4,47 @@ import {
   DataQueryRequest,
   DataQueryResponse,
   DataSourceInstanceSettings,
+  DataSourceWithLogsContextSupport,
+  DataSourceWithQueryModificationSupport,
   DataSourceWithSupplementaryQueriesSupport,
+  LogRowContextOptions,
+  LogRowContextQueryDirection,
+  LogRowModel,
   MetricFindValue,
+  QueryFixAction,
   ScopedVars,
   SupplementaryQueryType,
+  TimeRange,
 } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
-import { Observable } from 'rxjs';
+import { firstValueFrom, map, Observable } from 'rxjs';
 import { DatabendConfig } from 'types/config';
 import { DatabendQuery, EditorType, QueryType, queryTypeToFormat } from 'types/sql';
+import { transformQueryResponseWithTraceAndLogLinks } from './utils';
+
+const DEFAULT_AD_HOC_TAG_LIMIT = 1000;
 
 export class DatabendDatasource
   extends DataSourceWithBackend<DatabendQuery, DatabendConfig>
-  implements DataSourceWithSupplementaryQueriesSupport<DatabendQuery>
+  implements
+    DataSourceWithSupplementaryQueriesSupport<DatabendQuery>,
+    DataSourceWithLogsContextSupport<DatabendQuery>,
+    DataSourceWithQueryModificationSupport<DatabendQuery>
 {
-  annotations = {};
+  annotations = {
+    prepareAnnotation,
+    prepareQuery(anno: any): DatabendQuery | undefined {
+      if (!anno?.target?.rawSql && !anno?.rawQuery) {
+        return undefined;
+      }
+      return {
+        refId: anno.name || 'Anno',
+        rawSql: anno.target?.rawSql || anno.rawQuery || '',
+        editorType: EditorType.SQL,
+        format: queryTypeToFormat(QueryType.Table),
+      } as DatabendQuery;
+    },
+  };
   settings: DataSourceInstanceSettings<DatabendConfig>;
 
   constructor(instanceSettings: DataSourceInstanceSettings<DatabendConfig>) {
@@ -26,13 +52,14 @@ export class DatabendDatasource
     this.settings = instanceSettings;
   }
 
-  applyTemplateVariables(query: DatabendQuery, scopedVars: ScopedVars): DatabendQuery {
+  applyTemplateVariables(query: DatabendQuery, scopedVars: ScopedVars, filters?: any[]): DatabendQuery {
+    const interpolated = this.replace(query.rawSql, scopedVars) || '';
+    const withAdHoc = filters && filters.length > 0 ? applyAdHocFilters(interpolated, filters) : interpolated;
     return {
       ...query,
-      rawSql: this.replace(query.rawSql, scopedVars) || '',
+      rawSql: withAdHoc,
     };
   }
-
   replace(value?: string, scopedVars?: ScopedVars): string | undefined {
     if (value !== undefined) {
       return getTemplateSrv().replace(value, scopedVars, this.format);
@@ -58,7 +85,11 @@ export class DatabendDatasource
   }
 
   query(request: DataQueryRequest<DatabendQuery>): Observable<DataQueryResponse> {
-    return super.query(request);
+    return super.query(request).pipe(
+      map((res: DataQueryResponse) => {
+        return transformQueryResponseWithTraceAndLogLinks(this, request, res);
+      })
+    );
   }
 
   // Supplementary queries support (LogsVolume in Explore)
@@ -75,19 +106,31 @@ export class DatabendDatasource
     }
 
     // Only generate volume query for logs queries
-    const queryType = (originalQuery as any).queryType;
-    if (queryType !== QueryType.Logs) {
+    if (originalQuery.queryType !== QueryType.Logs) {
       return undefined;
     }
+    const jsonData = this.settings.jsonData;
+    const db = jsonData.defaultDatabase || 'default';
+    const logsTable = jsonData.logsTable || 'otel_logs';
+    const tableRef = `${db}.${logsTable}`;
+    const timeColumn = jsonData.logsTimeColumn || 'timestamp';
+    const levelColumn = jsonData.logsLevelColumn || 'level';
 
-    const logsTable = this.settings.jsonData.logsTable || 'otel_logs';
-    const timeColumn = this.settings.jsonData.logsTimeColumn || 'timestamp';
-    const levelColumn = this.settings.jsonData.logsLevelColumn || 'level';
+    const rawSql = [
+      `SELECT $__timeInterval(${timeColumn}) AS time,`,
+      `       ${levelColumn} AS level,`,
+      `       count(*) AS count`,
+      `FROM ${tableRef}`,
+      `WHERE $__timeFilter(${timeColumn})`,
+      `GROUP BY time, ${levelColumn}`,
+      `ORDER BY time ASC`,
+    ].join('\n');
 
     return {
       ...originalQuery,
       refId: `log-volume-${originalQuery.refId}`,
-      rawSql: `SELECT $__timeInterval(${timeColumn}) as time, ${levelColumn} as level, count(*) as count FROM ${logsTable} WHERE $__timeFilter(${timeColumn}) GROUP BY time, level ORDER BY time ASC`,
+      rawSql,
+      editorType: EditorType.SQL,
       format: queryTypeToFormat(QueryType.TimeSeries),
       queryType: QueryType.TimeSeries,
     } as DatabendQuery;
@@ -102,7 +145,7 @@ export class DatabendDatasource
     }
 
     const logsTargets = request.targets.filter(
-      (t) => !t.hide && (t as any).queryType === QueryType.Logs
+      (t) => !t.hide && t.queryType === QueryType.Logs
     );
     if (logsTargets.length === 0) {
       return undefined;
@@ -133,6 +176,136 @@ export class DatabendDatasource
     return this.query(supplementaryRequest);
   }
 
+  // --- Logs Context Support ---
+
+  async getLogRowContext(
+    row: LogRowModel,
+    options?: LogRowContextOptions,
+    query?: DatabendQuery
+  ): Promise<DataQueryResponse> {
+    if (!query) {
+      throw new Error('Missing query for log context');
+    }
+    if (!options || !options.direction || options.limit === undefined) {
+      throw new Error('Missing log context options for query');
+    }
+    const timeColumn = this.settings.jsonData.logsTimeColumn || 'timestamp';
+    const logsTable = this.settings.jsonData.logsTable || 'otel_logs';
+    const db = this.settings.jsonData.defaultDatabase || 'default';
+
+    const direction = options.direction;
+    const limit = options.limit;
+    const timeOperator =
+      direction === LogRowContextQueryDirection.Forward ? '>=' : '<=';
+    const orderDir =
+      direction === LogRowContextQueryDirection.Forward ? 'ASC' : 'DESC';
+
+    // Use the row's timestamp (nanoseconds epoch) to filter context
+    const timeNs = row.timeEpochNs;
+    const timeSec = Number(BigInt(timeNs) / BigInt(1000000000));
+
+    const rawSql = `SELECT * FROM ${db}.${logsTable} WHERE ${timeColumn} ${timeOperator} to_timestamp(${timeSec}) ORDER BY ${timeColumn} ${orderDir} LIMIT ${limit}`;
+
+    const contextQuery: DatabendQuery = {
+      ...query,
+      refId: `log-context-${query.refId}`,
+      rawSql,
+    };
+
+    const req: DataQueryRequest<DatabendQuery> = {
+      targets: [contextQuery],
+      range: (getTemplateSrv() as unknown as { timeRange?: TimeRange }).timeRange as TimeRange,
+    } as DataQueryRequest<DatabendQuery>;
+
+    return firstValueFrom(super.query(req));
+  }
+
+  showContextToggle(row?: LogRowModel): boolean {
+    return true;
+  }
+
+  // --- Query Modification Support (modifyQuery) ---
+
+  modifyQuery(query: DatabendQuery, action: QueryFixAction): DatabendQuery {
+    if (!action.options || !action.options.value) {
+      return query;
+    }
+
+    const key = action.options.key || '';
+    const value = action.options.value;
+
+    if (!key) {
+      return query;
+    }
+
+    let rawSql = query.rawSql || '';
+    if (action.type === 'ADD_FILTER') {
+      const filterClause = `${key} = '${value}'`;
+      rawSql = addFilterToSql(rawSql, filterClause);
+    } else if (action.type === 'ADD_FILTER_OUT') {
+      const filterClause = `${key} != '${value}'`;
+      rawSql = addFilterToSql(rawSql, filterClause);
+    } else if (action.type === 'ADD_STRING_FILTER') {
+      const filterClause = `${key} LIKE '%${value}%'`;
+      rawSql = addFilterToSql(rawSql, filterClause);
+    } else if (action.type === 'ADD_STRING_FILTER_OUT') {
+      const filterClause = `${key} NOT LIKE '%${value}%'`;
+      rawSql = addFilterToSql(rawSql, filterClause);
+    }
+
+    return {
+      ...query,
+      rawSql,
+    };
+  }
+
+  getSupportedQueryModifications(): string[] {
+    return ['ADD_FILTER', 'ADD_FILTER_OUT', 'ADD_STRING_FILTER', 'ADD_STRING_FILTER_OUT'];
+  }
+
+  // --- Ad-Hoc Filters Support ---
+
+  async getTagKeys(): Promise<MetricFindValue[]> {
+    const table = this.settings.jsonData.defaultAdHocTable;
+    const db = this.settings.jsonData.defaultDatabase || 'default';
+    if (!table) {
+      return [];
+    }
+    try {
+      const columns = await this.fetchColumns(db, table);
+      return columns.map((c) => ({ text: c.name }));
+    } catch (err) {
+      console.warn('[databend] failed to fetch tag keys', err);
+      return [];
+    }
+  }
+
+  async getTagValues({ key }: any): Promise<MetricFindValue[]> {
+    const table = this.settings.jsonData.defaultAdHocTable;
+    const db = this.settings.jsonData.defaultDatabase || 'default';
+    if (!table || !key) {
+      return [];
+    }
+
+    // Basic identifier sanity check - bail out if the key contains dangerous chars.
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      console.warn(`[databend] refused to interpolate suspicious tag key: ${key}`);
+      return [];
+    }
+
+    try {
+      const result = await this.metricFindQuery(
+        `SELECT DISTINCT ${key} FROM ${db}.${table} WHERE ${key} IS NOT NULL LIMIT ${DEFAULT_AD_HOC_TAG_LIMIT}`
+      );
+      return result;
+    } catch (err) {
+      console.warn(`[databend] failed to fetch tag values for ${key}`, err);
+      return [];
+    }
+  }
+
+  // --- Metric Find / Helper Methods ---
+
   async metricFindQuery(sql: string, options?: any): Promise<MetricFindValue[]> {
     if (!sql) {
       return [];
@@ -157,12 +330,7 @@ export class DatabendDatasource
   }
 
   private async querySync(request: DataQueryRequest<DatabendQuery>): Promise<DataQueryResponse> {
-    return new Promise((resolve, reject) => {
-      super.query(request).subscribe({
-        next: (response) => resolve(response),
-        error: (error) => reject(error),
-      });
-    });
+    return firstValueFrom(super.query(request));
   }
 
   private mapMetricFindResponse(response: DataQueryResponse): MetricFindValue[] {
@@ -205,4 +373,94 @@ export class DatabendDatasource
     const result = await this.metricFindQuery(`DESCRIBE ${database}.${table}`);
     return result.map(r => ({ name: r.text, type: String(r.value || 'String') }));
   }
+}
+
+// Helper to add a filter clause to an existing SQL query
+function addFilterToSql(sql: string, filterClause: string): string {
+  const whereIndex = sql.toLowerCase().lastIndexOf('where');
+  if (whereIndex === -1) {
+    // No WHERE clause, try to insert before ORDER BY / GROUP BY / LIMIT
+    const insertBefore = sql.match(/\b(ORDER BY|GROUP BY|LIMIT)\b/i);
+    if (insertBefore && insertBefore.index !== undefined) {
+      return sql.slice(0, insertBefore.index) + 'WHERE ' + filterClause + ' ' + sql.slice(insertBefore.index);
+    }
+    return sql + ' WHERE ' + filterClause;
+  }
+  // Insert after existing WHERE
+  const afterWhere = whereIndex + 5;
+  return sql.slice(0, afterWhere) + ' ' + filterClause + ' AND' + sql.slice(afterWhere);
+}
+
+/**
+ * Apply Grafana ad-hoc filters to an already interpolated SQL string.
+ * Each filter has the shape { key, operator, value }.
+ */
+function applyAdHocFilters(sql: string, filters: any[]): string {
+  if (!filters || filters.length === 0) {
+    return sql;
+  }
+  let out = sql;
+  for (const f of filters) {
+    if (!f || !f.key) {
+      continue;
+    }
+    // Only allow safe identifiers for ad-hoc keys
+    if (!/^[A-Za-z_][A-Za-z0-9_.]*$/.test(f.key)) {
+      continue;
+    }
+    const clause = buildAdHocClause(f);
+    if (clause) {
+      out = addFilterToSql(out, clause);
+    }
+  }
+  return out;
+}
+
+function buildAdHocClause(f: any): string {
+  const op = String(f.operator || '=').toUpperCase();
+  const value = f.value;
+  const key = f.key;
+  switch (op) {
+    case '=':
+    case '!=':
+    case '<':
+    case '<=':
+    case '>':
+    case '>=':
+      if (typeof value === 'number') {
+        return `${key} ${op} ${value}`;
+      }
+      return `${key} ${op} '${escapeSqlString(String(value ?? ''))}'`;
+    case '=~':
+      return `${key} LIKE '%${escapeSqlString(String(value ?? ''))}%'`;
+    case '!~':
+      return `${key} NOT LIKE '%${escapeSqlString(String(value ?? ''))}%'`;
+    default:
+      return `${key} ${op} '${escapeSqlString(String(value ?? ''))}'`;
+  }
+}
+
+function escapeSqlString(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/**
+ * Normalize annotation queries from the legacy shape (bare `query` string) into
+ * the current shape Grafana expects (`target: { rawSql }`).
+ * Returns an AnnotationQuery compatible object.
+ */
+function prepareAnnotation(anno: any): any {
+  const next = { ...anno };
+  next.target = next.target || {};
+  if (typeof next.target.rawSql !== 'string') {
+    next.target.rawSql = typeof next.query === 'string' ? next.query : '';
+  }
+  if (!next.target.refId) {
+    next.target.refId = next.name || 'Anno';
+  }
+  if (!next.target.editorType) {
+    next.target.editorType = EditorType.SQL;
+  }
+  delete next.query;
+  return next;
 }

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -4,44 +4,64 @@ import {
   AggregateType,
   ColumnHint,
   Filter,
+  SelectedColumn,
 } from 'types/queryBuilder';
 
 export function generateSql(options: QueryBuilderOptions): string {
-  const { database, table, mode, columns, aggregates, groupBy, filters, orderBy, limit } = options;
-
+  const { table, queryType } = options;
   if (!table) {
     return '';
   }
+
+  // Special handling for trace-id detail mode: look up a single trace's spans
+  if (queryType === 'traces' && options.meta?.isTraceIdMode) {
+    return generateTraceIdSql(options);
+  }
+
+  // Special handling for traces search: shape columns for trace list visualization
+  if (queryType === 'traces') {
+    return generateTracesSearchSql(options);
+  }
+
+  // Special handling for logs
+  if (queryType === 'logs') {
+    return generateLogsSql(options);
+  }
+
+  return generateGenericSql(options);
+}
+
+/**
+ * Generic SQL generator for table, timeseries, and aggregate/trend modes.
+ */
+function generateGenericSql(options: QueryBuilderOptions): string {
+  const { database, table, mode, columns, aggregates, groupBy, filters, orderBy, limit, queryType } = options;
 
   const parts: string[] = [];
   const tableRef = database ? `${database}.${table}` : table;
 
   // SELECT
   const selectParts: string[] = [];
-
   if (mode === BuilderMode.Aggregate || mode === BuilderMode.Trend) {
-    // Group by columns
     if (groupBy && groupBy.length > 0) {
       selectParts.push(...groupBy);
     }
-    // Time column for trend
     if (mode === BuilderMode.Trend) {
-      const timeCol = columns.find(c => c.hint === ColumnHint.Time);
+      const timeCol = columns.find((c) => c.hint === ColumnHint.Time);
       if (timeCol) {
-        selectParts.push(`$__timeInterval(${timeCol.name})`);
+        selectParts.push(`$__timeInterval(${timeCol.name}) AS time`);
       }
     }
-    // Aggregates
     if (aggregates && aggregates.length > 0) {
       for (const agg of aggregates) {
-        const aggExpr = agg.aggregateType === AggregateType.Count
-          ? `count(${agg.column || '*'})`
-          : `${agg.aggregateType}(${agg.column})`;
+        const aggExpr =
+          agg.aggregateType === AggregateType.Count
+            ? `count(${agg.column || '*'})`
+            : `${agg.aggregateType}(${agg.column})`;
         selectParts.push(agg.alias ? `${aggExpr} AS ${agg.alias}` : aggExpr);
       }
     }
   } else {
-    // List mode
     if (columns.length > 0) {
       for (const col of columns) {
         selectParts.push(col.alias ? `${col.name} AS ${col.alias}` : col.name);
@@ -55,21 +75,11 @@ export function generateSql(options: QueryBuilderOptions): string {
   parts.push(`FROM ${tableRef}`);
 
   // WHERE
-  const whereParts: string[] = [];
-  if (filters && filters.length > 0) {
-    for (const filter of filters) {
-      const filterSql = buildFilterSql(filter);
-      if (filterSql) {
-        whereParts.push(filterSql);
-      }
-    }
-  }
-  // Add time filter for time series
-  const timeCol = columns.find(c => c.hint === ColumnHint.Time);
-  if (timeCol && (mode === BuilderMode.Trend || options.queryType === 'timeseries')) {
+  const whereParts: string[] = buildWhereClauses(filters);
+  const timeCol = columns.find((c) => c.hint === ColumnHint.Time);
+  if (timeCol && (mode === BuilderMode.Trend || queryType === 'timeseries')) {
     whereParts.push(`$__timeFilter(${timeCol.name})`);
   }
-
   if (whereParts.length > 0) {
     parts.push(`WHERE ${whereParts.join(' AND ')}`);
   }
@@ -90,8 +100,7 @@ export function generateSql(options: QueryBuilderOptions): string {
 
   // ORDER BY
   if (orderBy && orderBy.length > 0) {
-    const orderParts = orderBy.map(o => `${o.name} ${o.dir}`);
-    parts.push(`ORDER BY ${orderParts.join(', ')}`);
+    parts.push(`ORDER BY ${orderBy.map((o) => `${o.name} ${o.dir}`).join(', ')}`);
   } else if (mode === BuilderMode.Trend && timeCol) {
     parts.push(`ORDER BY $__timeInterval(${timeCol.name}) ASC`);
   }
@@ -104,13 +113,215 @@ export function generateSql(options: QueryBuilderOptions): string {
   return parts.join('\n');
 }
 
+/**
+ * Logs SQL generator. Always applies time filter on the time column
+ * and orders by time DESC unless the user overrides.
+ */
+function generateLogsSql(options: QueryBuilderOptions): string {
+  const { database, table, columns, filters, orderBy, limit } = options;
+
+  const parts: string[] = [];
+  const tableRef = database ? `${database}.${table}` : table;
+
+  const timeCol = columns.find((c) => c.hint === ColumnHint.Time);
+
+  // SELECT
+  const selectParts: string[] = [];
+  if (columns.length > 0) {
+    for (const col of columns) {
+      selectParts.push(formatColumn(col));
+    }
+  } else {
+    selectParts.push('*');
+  }
+
+  parts.push(`SELECT ${selectParts.join(', ')}`);
+  parts.push(`FROM ${tableRef}`);
+
+  const whereParts = buildWhereClauses(filters);
+  if (timeCol) {
+    whereParts.push(`$__timeFilter(${timeCol.name})`);
+  }
+  if (whereParts.length > 0) {
+    parts.push(`WHERE ${whereParts.join(' AND ')}`);
+  }
+
+  if (orderBy && orderBy.length > 0) {
+    parts.push(`ORDER BY ${orderBy.map((o) => `${o.name} ${o.dir}`).join(', ')}`);
+  } else if (timeCol) {
+    parts.push(`ORDER BY ${timeCol.name} DESC`);
+  }
+
+  parts.push(`LIMIT ${limit && limit > 0 ? limit : 1000}`);
+  return parts.join('\n');
+}
+
+/**
+ * Traces SEARCH SQL generator. Builds a list of traces, grouped by traceID,
+ * so Grafana renders the trace search result view.
+ */
+function generateTracesSearchSql(options: QueryBuilderOptions): string {
+  const { database, table, columns, filters, orderBy, limit } = options;
+
+  const parts: string[] = [];
+  const tableRef = database ? `${database}.${table}` : table;
+
+  const traceIdCol = columns.find((c) => c.hint === ColumnHint.TraceId);
+  const serviceCol = columns.find((c) => c.hint === ColumnHint.TraceServiceName);
+  const operationCol = columns.find((c) => c.hint === ColumnHint.TraceOperationName);
+  const durationCol = columns.find((c) => c.hint === ColumnHint.TraceDurationTime);
+  const startTimeCol = columns.find((c) => c.hint === ColumnHint.Time);
+
+  const durationUnit = (options.meta?.traceDurationUnit as string) || 'ms';
+
+  const selectParts: string[] = [];
+  if (traceIdCol) {
+    selectParts.push(`${traceIdCol.name} AS traceID`);
+  }
+  if (startTimeCol) {
+    selectParts.push(`min(${startTimeCol.name}) AS startTime`);
+  }
+  if (serviceCol) {
+    selectParts.push(`any(${serviceCol.name}) AS serviceName`);
+  }
+  if (operationCol) {
+    selectParts.push(`any(${operationCol.name}) AS operationName`);
+  }
+  if (durationCol) {
+    selectParts.push(`${convertDuration(`sum(${durationCol.name})`, durationUnit)} AS duration`);
+  }
+
+  if (selectParts.length === 0) {
+    return generateGenericSql(options);
+  }
+
+  parts.push(`SELECT ${selectParts.join(', ')}`);
+  parts.push(`FROM ${tableRef}`);
+
+  const whereParts = buildWhereClauses(filters);
+  if (startTimeCol) {
+    whereParts.push(`$__timeFilter(${startTimeCol.name})`);
+  }
+  if (whereParts.length > 0) {
+    parts.push(`WHERE ${whereParts.join(' AND ')}`);
+  }
+
+  if (traceIdCol) {
+    parts.push(`GROUP BY ${traceIdCol.name}`);
+  }
+
+  if (orderBy && orderBy.length > 0) {
+    parts.push(`ORDER BY ${orderBy.map((o) => `${o.name} ${o.dir}`).join(', ')}`);
+  } else {
+    parts.push(`ORDER BY startTime DESC`);
+  }
+
+  parts.push(`LIMIT ${limit && limit > 0 ? limit : 100}`);
+  return parts.join('\n');
+}
+
+/**
+ * Trace-detail SQL generator: returns all spans for a single traceID
+ * with the column shape expected by Grafana's trace viewer.
+ */
+function generateTraceIdSql(options: QueryBuilderOptions): string {
+  const { database, table, columns } = options;
+  const tableRef = database ? `${database}.${table}` : table;
+
+  const traceIdCol = columns.find((c) => c.hint === ColumnHint.TraceId);
+  const spanIdCol = columns.find((c) => c.hint === ColumnHint.TraceSpanId);
+  const parentSpanIdCol = columns.find((c) => c.hint === ColumnHint.TraceParentSpanId);
+  const serviceCol = columns.find((c) => c.hint === ColumnHint.TraceServiceName);
+  const operationCol = columns.find((c) => c.hint === ColumnHint.TraceOperationName);
+  const durationCol = columns.find((c) => c.hint === ColumnHint.TraceDurationTime);
+  const startTimeCol = columns.find((c) => c.hint === ColumnHint.Time);
+
+  const durationUnit = (options.meta?.traceDurationUnit as string) || 'ms';
+  const traceId = (options.meta?.traceId as string) || '';
+
+  const selectParts: string[] = [];
+  if (traceIdCol) {
+    selectParts.push(`${traceIdCol.name} AS traceID`);
+  }
+  if (spanIdCol) {
+    selectParts.push(`${spanIdCol.name} AS spanID`);
+  }
+  if (parentSpanIdCol) {
+    selectParts.push(`${parentSpanIdCol.name} AS parentSpanID`);
+  } else {
+    selectParts.push(`'' AS parentSpanID`);
+  }
+  if (serviceCol) {
+    selectParts.push(`${serviceCol.name} AS serviceName`);
+  }
+  if (operationCol) {
+    selectParts.push(`${operationCol.name} AS operationName`);
+  }
+  if (startTimeCol) {
+    selectParts.push(`${startTimeCol.name} AS startTime`);
+  }
+  if (durationCol) {
+    selectParts.push(`${convertDuration(durationCol.name, durationUnit)} AS duration`);
+  }
+
+  const parts: string[] = [];
+  parts.push(`SELECT ${selectParts.join(', ')}`);
+  parts.push(`FROM ${tableRef}`);
+
+  const whereParts: string[] = [];
+  if (traceIdCol && traceId) {
+    whereParts.push(`${traceIdCol.name} = '${traceId}'`);
+  }
+  if (whereParts.length > 0) {
+    parts.push(`WHERE ${whereParts.join(' AND ')}`);
+  }
+
+  if (startTimeCol) {
+    parts.push(`ORDER BY ${startTimeCol.name} ASC`);
+  }
+
+  parts.push(`LIMIT 1000`);
+  return parts.join('\n');
+}
+
+function formatColumn(col: SelectedColumn): string {
+  return col.alias ? `${col.name} AS ${col.alias}` : col.name;
+}
+
+function buildWhereClauses(filters?: Filter[]): string[] {
+  const out: string[] = [];
+  if (!filters || filters.length === 0) {
+    return out;
+  }
+  for (const filter of filters) {
+    const sql = buildFilterSql(filter);
+    if (sql) {
+      out.push(sql);
+    }
+  }
+  return out;
+}
+
+function convertDuration(expr: string, unit: string): string {
+  // Grafana's trace viewer expects duration in milliseconds.
+  switch (unit) {
+    case 'ns':
+      return `${expr} / 1000000`;
+    case 'us':
+      return `${expr} / 1000`;
+    case 's':
+      return `${expr} * 1000`;
+    case 'ms':
+    default:
+      return expr;
+  }
+}
+
 function buildFilterSql(filter: Filter): string {
   if (!filter.key || filter.operator === 'IS ANYTHING') {
     return '';
   }
-
   const { key, operator, value } = filter;
-
   switch (operator) {
     case 'IS NULL':
     case 'IS NOT NULL':
@@ -118,7 +329,7 @@ function buildFilterSql(filter: Filter): string {
     case 'IN':
     case 'NOT IN':
       if (Array.isArray(value)) {
-        return `${key} ${operator} (${value.map(v => `'${v}'`).join(', ')})`;
+        return `${key} ${operator} (${value.map((v) => `'${v}'`).join(', ')})`;
       }
       return `${key} ${operator} ('${value}')`;
     default:

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -1,0 +1,216 @@
+import { CoreApp, DataFrame, DataQueryRequest, DataQueryResponse, FieldConfig } from '@grafana/data';
+import { DatabendDatasource } from './datasource';
+import { DatabendQuery, DatabendBuilderQuery, EditorType, QueryType, queryTypeToFormat } from '../types/sql';
+import { BuilderMode, ColumnHint, FilterOperator, OrderByDirection } from '../types/queryBuilder';
+import { generateSql } from './sqlGenerator';
+
+/**
+ * Field config map for trace search result columns.
+ * Maps column name (lowercase) to Grafana FieldConfig for better default display.
+ */
+const traceSearchFieldConfigs: Record<string, FieldConfig> = {
+  duration: {
+    unit: 'ms',
+    displayName: 'Duration',
+  },
+  starttime: {
+    displayName: 'Start Time',
+  },
+  start_time: {
+    displayName: 'Start Time',
+  },
+  servicename: {
+    displayName: 'Service Name',
+  },
+  service_name: {
+    displayName: 'Service Name',
+  },
+  operationname: {
+    displayName: 'Operation Name',
+  },
+  operation_name: {
+    displayName: 'Operation Name',
+  },
+  traceid: {
+    displayName: 'Trace ID',
+  },
+  trace_id: {
+    displayName: 'Trace ID',
+  },
+};
+
+/**
+ * Applies field configs to trace search result frames for better default display.
+ */
+export const applyTraceSearchFieldConfig = (req: DataQueryRequest<DatabendQuery>, res: DataQueryResponse): void => {
+  res.data.forEach((frame: DataFrame) => {
+    const originalQuery = req.targets.find((t) => t.refId === frame.refId);
+    if (!originalQuery) {
+      return;
+    }
+    const isTraceSearch =
+      originalQuery.editorType === EditorType.Builder &&
+      (originalQuery as DatabendBuilderQuery).builderOptions?.queryType === 'traces' &&
+      !(originalQuery as DatabendBuilderQuery).builderOptions?.meta?.isTraceIdMode;
+
+    if (!isTraceSearch) {
+      return;
+    }
+
+    frame.fields.forEach((field) => {
+      const fieldConfig = traceSearchFieldConfigs[field.name.toLowerCase()];
+      if (fieldConfig) {
+        field.config = {
+          ...field.config,
+          ...fieldConfig,
+        };
+      }
+    });
+  });
+};
+
+/**
+ * Mutates the DataQueryResponse to include trace/log links on the traceID field.
+ * The link will open a second query editor in split view on the explore page
+ * with the selected trace ID.
+ */
+export const transformQueryResponseWithTraceAndLogLinks = (
+  datasource: DatabendDatasource,
+  req: DataQueryRequest<DatabendQuery>,
+  res: DataQueryResponse
+): DataQueryResponse => {
+  applyTraceSearchFieldConfig(req, res);
+
+  const settings = datasource.settings.jsonData;
+  const showTraceLinks = settings.showTraceLinks !== false;
+  const showLogLinks = settings.showLogLinks !== false;
+
+  if (!showTraceLinks && !showLogLinks) {
+    return res;
+  }
+
+  res.data.forEach((frame: DataFrame) => {
+    const originalQuery = req.targets.find((t) => t.refId === frame.refId);
+    if (!originalQuery) {
+      return;
+    }
+
+    const traceField = frame.fields.find(
+      (field) => field.name.toLowerCase() === 'traceid' || field.name.toLowerCase() === 'trace_id'
+    );
+
+    if (!traceField) {
+      return;
+    }
+
+    // Build trace ID query
+    const traceIdColumn = settings.tracesTraceIdColumn || 'trace_id';
+    const tracesTable = settings.tracesTable || 'otel_traces';
+    const tracesDb = settings.defaultDatabase || 'default';
+    const traceIdQuery: DatabendBuilderQuery = {
+      refId: 'Trace ID',
+      editorType: EditorType.Builder,
+      rawSql: '',
+      builderOptions: {
+        database: tracesDb,
+        table: tracesTable,
+        queryType: 'traces',
+        mode: BuilderMode.List,
+        columns: [
+          { name: traceIdColumn, hint: ColumnHint.TraceId },
+          { name: settings.tracesSpanIdColumn || 'span_id', hint: ColumnHint.TraceSpanId },
+          { name: settings.tracesOperationNameColumn || 'operation_name', hint: ColumnHint.TraceOperationName },
+          { name: settings.tracesServiceNameColumn || 'service_name', hint: ColumnHint.TraceServiceName },
+          { name: settings.tracesDurationColumn || 'duration', hint: ColumnHint.TraceDurationTime },
+          { name: settings.tracesStartTimeColumn || 'timestamp', hint: ColumnHint.Time },
+        ],
+        filters: [],
+        orderBy: [],
+        meta: {
+          isTraceIdMode: true,
+          traceId: '${__value.raw}',
+          traceDurationUnit: settings.tracesDurationUnit || 'ms',
+        },
+      },
+    };
+
+    // Generate rawSql for the trace query
+    const openInNewWindow = req.app !== CoreApp.Explore;
+    traceIdQuery.rawSql = generateSql(traceIdQuery.builderOptions);
+
+    // Build logs query filtered by traceId
+    const logsTable = settings.logsTable || 'otel_logs';
+    const logsTimeColumn = settings.logsTimeColumn || 'timestamp';
+    const logsLevelColumn = settings.logsLevelColumn || 'level';
+    const logsMessageColumn = settings.logsMessageColumn || 'body';
+
+    const traceLogsQuery: DatabendBuilderQuery = {
+      refId: 'Trace Logs',
+      editorType: EditorType.Builder,
+      rawSql: '',
+      builderOptions: {
+        database: tracesDb,
+        table: logsTable,
+        queryType: 'logs',
+        mode: BuilderMode.List,
+        columns: [
+          { name: logsTimeColumn, hint: ColumnHint.Time },
+          { name: logsLevelColumn, hint: ColumnHint.LogLevel },
+          { name: logsMessageColumn, hint: ColumnHint.LogMessage },
+          { name: traceIdColumn, hint: ColumnHint.TraceId },
+        ],
+        filters: [
+          {
+            key: traceIdColumn,
+            operator: FilterOperator.Equals,
+            value: '${__value.raw}',
+          },
+        ],
+        orderBy: [{ name: logsTimeColumn, dir: OrderByDirection.ASC }],
+      },
+      format: queryTypeToFormat(QueryType.Logs),
+    };
+    // Generate rawSql for Dashboard mode to preserve query through serialization
+    if (openInNewWindow) {
+      traceLogsQuery.rawSql = generateSql(traceLogsQuery.builderOptions);
+    } else {
+      traceLogsQuery.rawSql = '';
+    }
+
+    traceField.config = traceField.config || {};
+    traceField.config.links = [];
+
+    if (showTraceLinks) {
+      traceField.config.links.push({
+        title: 'View trace',
+        targetBlank: openInNewWindow,
+        url: '',
+        internal: {
+          query: traceIdQuery,
+          datasourceUid: datasource.uid,
+          datasourceName: datasource.type,
+          panelsState: {
+            trace: {
+              spanId: '${__value.raw}',
+            },
+          },
+        },
+      });
+    }
+
+    if (showLogLinks) {
+      traceField.config.links.push({
+        title: 'View logs',
+        targetBlank: openInNewWindow,
+        url: '',
+        internal: {
+          query: traceLogsQuery,
+          datasourceUid: datasource.uid,
+          datasourceName: datasource.type,
+        },
+      });
+    }
+  });
+
+  return res;
+};

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -12,6 +12,7 @@ export interface DatabendConfig extends DataSourceJsonData {
   logsTimeColumn?: string;
   logsLevelColumn?: string;
   logsMessageColumn?: string;
+  showLogLinks?: boolean;
 
   // Traces
   tracesTable?: string;
@@ -22,6 +23,10 @@ export interface DatabendConfig extends DataSourceJsonData {
   tracesDurationColumn?: string;
   tracesDurationUnit?: string;
   tracesStartTimeColumn?: string;
+  showTraceLinks?: boolean;
+
+  // Ad-hoc filters
+  defaultAdHocTable?: string;
 }
 
 export interface DatabendSecureConfig {

--- a/src/types/sql.ts
+++ b/src/types/sql.ts
@@ -18,11 +18,11 @@ export interface DatabendQueryBase extends DataQuery {
   editorType: EditorType;
   rawSql: string;
   format?: number;
+  queryType?: QueryType;
 }
 
 export interface DatabendSqlQuery extends DatabendQueryBase {
   editorType: EditorType.SQL;
-  queryType?: QueryType;
   meta?: {
     timezone?: string;
     builderOptions?: QueryBuilderOptions;


### PR DESCRIPTION
## Problem
The plugin advertises logs, traces, annotations, and ad-hoc filter support in `plugin.json`, but the datasource only partially honoured those contracts: the query builder had no way to tag logs/traces columns, `sqlGenerator` emitted a single generic SHAPE for every query type, `applyTemplateVariables` ignored Grafana ad-hoc filters, the log-volume supplementary query forgot its time filter and database prefix, and `annotations` was left as an empty object so annotation queries silently no-oped.

## Approach
Bring each surface up to what Grafana actually expects:

- Split `sqlGenerator` into dedicated paths for logs, traces search, trace detail, and the generic list/aggregate/trend flows so each produces the columns Grafana's visualizations need (e.g. `traceID/spanID/parentSpanID/serviceName/operationName/startTime/duration` with duration normalized to ms via `tracesDurationUnit`).
- Hoist `queryType` onto the base query type and thread it through the editor so switching query type re-hints builder columns from the configured logs/traces schema and re-renders SQL in one go. Added a Hint panel in `QueryBuilder` so users can tag time/level/message/trace columns without hand-editing JSON.
- Wire ad-hoc filters into `applyTemplateVariables`, injecting each filter as an extra `WHERE` clause with key allow-listing and single-quote escaping. `getTagKeys` / `getTagValues` are now wrapped in try/catch and reject suspicious identifiers.
- Replace the empty `annotations` object with `prepareAnnotation` + `prepareQuery`, so existing SQL annotations migrate onto the new `target.rawSql` shape and new ones route through the SQL editor.
- Fix the log-volume SQL to fully qualify the table and wrap it in `$__timeFilter` so the volume panel actually honours the dashboard time range.

## Scope
- `src/data/sqlGenerator.ts` — logs / traces search / trace detail generators
- `src/data/datasource.ts` — ad-hoc filter interpolation, annotation wiring, log volume fix, tag key/value hardening
- `src/data/utils.ts` — already-present trace/log link transform now drives off the new `queryType` surface
- `src/components/QueryEditor.tsx` — queryType-driven hint hydration, cleaner meta handling
- `src/components/queryBuilder/QueryBuilder.tsx` — per-column Hint picker for logs/traces
- `src/components/SqlEditor.tsx` — remove stale `as any` around `expand`
- `src/components/ConfigEditor.tsx`, `src/types/config.ts` — expose `showLogLinks`, `showTraceLinks`, `defaultAdHocTable`
- `src/types/sql.ts` — move `queryType` onto the base query shape

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `go build ./...`
- [x] `go vet ./...`
