### PR TITLE
fix(frontend): remove format from defaultDatabendQuery

### DIFF
--- a/src/types/sql.ts
+++ b/src/types/sql.ts
@@ -62,6 +62,5 @@ export const defaultDatabendQuery: Omit<DatabendSqlQuery, 'refId'> = {
   pluginVersion: '',
   editorType: EditorType.SQL,
   rawSql: '',
-  format: queryTypeToFormat(QueryType.Table),
   expand: false,
 };


### PR DESCRIPTION
## Follow-up to #5

Remove `format` from `defaultDatabendQuery` to align with ClickHouse plugin's approach.

The `format` field should not live in the default query object — it should be derived from `queryType` at each `onChange` call site (which is already handled in `QueryEditor.tsx`). This matches how `defaultCHSqlQuery` works in the ClickHouse plugin.
