### PR TITLE
fix(frontend): set trace format on trace ID link query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-databend",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Grafana datasource plugin for Databend",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -111,6 +111,8 @@ export const transformQueryResponseWithTraceAndLogLinks = (
       refId: 'Trace ID',
       editorType: EditorType.Builder,
       rawSql: '',
+      format: queryTypeToFormat(QueryType.Traces),
+      queryType: QueryType.Traces,
       builderOptions: {
         database: tracesDb,
         table: tracesTable,


### PR DESCRIPTION
Without format and queryType on the traceIdQuery, clicking a trace ID opened a table view with full builder parameters instead of the trace visualization. Add format=Traces and queryType=Traces so Grafana renders the trace viewer directly.