### PR TITLE
fix: handle FieldTypeNullableJSON in trace attribute transformation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-databend",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Grafana datasource plugin for Databend",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -136,7 +136,7 @@ func convertJSONFieldsToString(frame *data.Frame) {
 //   - Already correct format: [{"key":"k","value":"v"}] → pass through
 func transformTraceAttributes(frame *data.Frame) {
 	for i, field := range frame.Fields {
-		if field.Type() != data.FieldTypeJSON {
+		if field.Type() != data.FieldTypeJSON && field.Type() != data.FieldTypeNullableJSON {
 			continue
 		}
 		name := field.Name
@@ -149,7 +149,19 @@ func transformTraceAttributes(frame *data.Frame) {
 				field.Set(j, json.RawMessage("[]"))
 				continue
 			}
-			raw := val.(json.RawMessage)
+			var raw json.RawMessage
+			switch v := val.(type) {
+			case json.RawMessage:
+				raw = v
+			case *json.RawMessage:
+				if v == nil {
+					field.Set(j, json.RawMessage("[]"))
+					continue
+				}
+				raw = *v
+			default:
+				continue
+			}
 			transformed := transformToKeyValueArray(raw, name)
 			frame.Fields[i].Set(j, transformed)
 		}


### PR DESCRIPTION
Fixes: `ze.reduce is not a function` error in Grafana trace panel.

`VARIANT NULL` columns (like `metadata:attributes`) go through the `Nullable(Variant)` converter and produce `FieldTypeNullableJSON`, but `transformTraceAttributes` only checked for `FieldTypeJSON`. The transformation was skipped entirely, passing raw JSON objects to the trace panel which expects arrays.

Also fixes the type assertion for nullable field values (`*json.RawMessage` vs `json.RawMessage`).