### PR TITLE
fix: require manual run for builder queries

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -135,7 +135,6 @@ export const QueryEditor: React.FC<Props> = (props) => {
       rawSql: newSql,
       format: queryTypeToFormat(builderQueryType),
     } as DatabendQuery);
-    onRunQuery();
   };
 
   return (
@@ -177,6 +176,7 @@ export const QueryEditor: React.FC<Props> = (props) => {
           onBuilderOptionsChange={onBuilderOptionsChange}
           generatedSql={generatedSql}
           queryType={queryType}
+          onRunQuery={onRunQuery}
         />
       )}
     </>

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -22,6 +22,7 @@ interface QueryBuilderProps {
   onBuilderOptionsChange: (options: QueryBuilderOptions) => void;
   generatedSql: string;
   queryType?: QueryType;
+  onRunQuery: () => void;
 }
 
 export const QueryBuilder: React.FC<QueryBuilderProps> = ({
@@ -30,6 +31,7 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
   onBuilderOptionsChange,
   generatedSql,
   queryType,
+  onRunQuery,
 }) => {
   const [databases, setDatabases] = useState<string[]>([]);
   const [tables, setTables] = useState<string[]>([]);
@@ -436,6 +438,9 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
             aria-label="Limit"
           />
         </InlineField>
+        <Button variant="primary" size="sm" icon="play" onClick={onRunQuery}>
+          Run query
+        </Button>
       </InlineFieldRow>
 
       {/* SQL Preview */}


### PR DESCRIPTION
## Problem
Changing SQL builder fields such as database, table, filters, or limit immediately triggered query execution, which made it easy to run unwanted queries while users were still configuring the builder.

## Approach
Keep builder option changes updating the generated SQL preview, but stop calling the query runner from the builder change handler. Add an explicit Run query button in the builder UI so execution only happens when the user requests it.

## Validation
- [x] pnpm run typecheck
