### PR TITLE
fix: support dashboard time range builder filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-databend",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Grafana datasource plugin for Databend",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/queryBuilder/QueryBuilder.tsx
+++ b/src/components/queryBuilder/QueryBuilder.tsx
@@ -126,6 +126,17 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
     onBuilderOptionsChange({ ...builderOptions, filters });
   };
 
+  const onAddTimeRangeFilter = () => {
+    const timeColumn = builderOptions.columns.find((c) => c.hint === ColumnHint.Time)?.name || '';
+    const newFilter: Filter = {
+      key: timeColumn,
+      operator: FilterOperator.WithInGrafanaTimeRange,
+      value: '',
+    };
+    const filters = [...(builderOptions.filters || []), newFilter];
+    onBuilderOptionsChange({ ...builderOptions, filters });
+  };
+
   const onAddAggregate = () => {
     const newAgg: AggregateColumn = { column: '*', aggregateType: AggregateType.Count };
     const aggregates = [...(builderOptions.aggregates || []), newAgg];
@@ -176,6 +187,7 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
   ];
 
   const filterOperatorOptions: Array<SelectableValue<FilterOperator>> = [
+    { label: 'Within dashboard time range', value: FilterOperator.WithInGrafanaTimeRange },
     { label: '=', value: FilterOperator.Equals },
     { label: '!=', value: FilterOperator.NotEquals },
     { label: '<', value: FilterOperator.LessThan },
@@ -370,7 +382,9 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
               aria-label="Filter Operator"
             />
           </InlineField>
-          {filter.operator !== FilterOperator.IsNull && filter.operator !== FilterOperator.IsNotNull && (
+          {filter.operator !== FilterOperator.IsNull &&
+            filter.operator !== FilterOperator.IsNotNull &&
+            filter.operator !== FilterOperator.WithInGrafanaTimeRange && (
             <InlineField label="">
               <Input
                 width={20}
@@ -390,6 +404,9 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
             Add Filter
           </Button>
         </InlineField>
+        <Button variant="secondary" size="sm" icon="clock-nine" onClick={onAddTimeRangeFilter}>
+          Add dashboard time range
+        </Button>
       </InlineFieldRow>
 
       {/* Order By */}

--- a/src/data/sqlGenerator.ts
+++ b/src/data/sqlGenerator.ts
@@ -4,6 +4,7 @@ import {
   AggregateType,
   ColumnHint,
   Filter,
+  FilterOperator,
   SelectedColumn,
 } from 'types/queryBuilder';
 
@@ -343,6 +344,8 @@ function buildFilterSql(filter: Filter): string {
   }
   const { key, operator, value } = filter;
   switch (operator) {
+    case FilterOperator.WithInGrafanaTimeRange:
+      return `$__timeFilter(${key})`;
     case 'IS NULL':
     case 'IS NOT NULL':
       return `${key} ${operator}`;

--- a/src/types/queryBuilder.ts
+++ b/src/types/queryBuilder.ts
@@ -49,7 +49,6 @@ export enum FilterOperator {
   IsNull = 'IS NULL',
   IsNotNull = 'IS NOT NULL',
   WithInGrafanaTimeRange = 'WITH IN DASHBOARD TIME RANGE',
-  OutsideGrafanaTimeRange = 'OUTSIDE DASHBOARD TIME RANGE',
 }
 
 export interface SelectedColumn {


### PR DESCRIPTION
## Problem
SQL builder queries do not consistently include Grafana's dashboard time range. Logs, traces, and trend/time-series paths add `$__timeFilter` when a time column hint is present, but table/list builder queries can run without the top-right dashboard time being represented in the generated SQL.

## Approach
Expose an explicit dashboard time range filter operator in the builder. Users can add a dashboard time range filter for the selected time column, which generates `$__timeFilter(column)`.

## Scope
- Add a “Within dashboard time range” operator to SQL builder filters
- Add a convenience “Add dashboard time range” button that preselects the hinted time column when available
- Generate Databend `$__timeFilter` SQL from that filter operator
- Bump plugin patch version to 1.4.5

## Validation
- [x] pnpm run typecheck
- [x] git diff --check
- [ ] pnpm run lint — blocked by existing project script incompatibility with ESLint flat config: `Invalid option '--ignore-path'`
