### PR TITLE
fix: address plugin review validation issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -22,4 +24,5 @@ jobs:
         with:
           go-version: '1.25'
           node-version: '24'
+          attestation: true
           # policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-databend",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Grafana datasource plugin for Databend",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
@@ -69,7 +69,8 @@
   },
   "pnpm": {
     "overrides": {
-      "immutable": ">=5.1.5"
+      "immutable": ">=5.1.5",
+      "js-cookie": "3.0.7"
     }
   },
   "packageManager": "pnpm@10.11.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   immutable: '>=5.1.5'
+  js-cookie: 3.0.7
 
 importers:
 
@@ -3122,8 +3123,9 @@ packages:
   jquery@3.7.1:
     resolution: {integrity: sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==}
 
-  js-cookie@2.2.1:
-    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -8562,7 +8564,7 @@ snapshots:
 
   jquery@3.7.1: {}
 
-  js-cookie@2.2.1: {}
+  js-cookie@3.0.7: {}
 
   js-tokens@4.0.0: {}
 
@@ -9350,7 +9352,7 @@ snapshots:
       copy-to-clipboard: 3.3.3
       fast-deep-equal: 3.1.3
       fast-shallow-equal: 1.0.0
-      js-cookie: 2.2.1
+      js-cookie: 3.0.7
       nano-css: 5.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
## Problem
Grafana plugin review reported two validation issues for the 1.4.5 submission: the lockfile resolved a high-severity vulnerable `js-cookie` version through `react-use`, and the release artifact did not include build provenance attestation.

## Approach
Pin the transitive `js-cookie` resolution to `3.0.7` with pnpm overrides because `react-use` is already at its latest release and still declares `js-cookie@^2.2.1`. Also enable provenance attestation in the Grafana plugin release workflow by granting the required GitHub Actions permissions and passing `attestation: true` to `grafana/plugin-actions/build-plugin`.

## Scope
- Bump plugin package version to `1.4.6`
- Override `js-cookie` to `3.0.7` and update `pnpm-lock.yaml`
- Enable release workflow provenance attestation

## Validation
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] Workflow YAML parsed successfully
- [ ] `pnpm run lint` currently fails because the existing ESLint 9 flat config setup rejects the script's deprecated `--ignore-path` flag
