### PR TITLE
fix: use attestation-capable plugin action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
-      - uses: grafana/plugin-actions/build-plugin@release
+      - uses: grafana/plugin-actions/build-plugin@build-plugin/v1.2.0
         with:
           go-version: '1.25'
           node-version: '24'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-databend",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Grafana datasource plugin for Databend",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## Problem
The release workflow passed `attestation: true` to `grafana/plugin-actions/build-plugin@release`, but that ref does not expose an `attestation` input. GitHub Actions therefore emitted an unexpected input warning and the v1.4.6 release run completed without build provenance attestation.

## Approach
Switch the Grafana build-plugin action to the documented `build-plugin/v1.2.0` ref, whose `action.yml` includes the `attestation` input and generates build provenance with `actions/attest-build-provenance` when enabled. Since v1.4.6 has already been tagged without attestation, bump the package patch version to v1.4.7 for the next release tag instead of rewriting the existing tag.

## Scope
- Update the release workflow action ref from `@release` to `@build-plugin/v1.2.0`
- Keep the existing `id-token: write`, `attestations: write`, and `attestation: true` settings
- Bump plugin package version to `1.4.7`

## Validation
- [x] Workflow YAML parsed successfully
- [x] `pnpm run typecheck`
