### PR TITLE
chore: enable plugin signing for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
           go-version: '1.25'
           node-version: '24'
           attestation: true
-          # policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+          policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-databend",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Grafana datasource plugin for Databend",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## Problem
Release artifacts should be signed with the Grafana access policy token now that the repository secret is configured, so the next plugin submission can include both signing and provenance attestation.

## Approach
Pass `GRAFANA_ACCESS_POLICY_TOKEN` into the Grafana plugin build action via `policy_token`, keeping the token in GitHub Secrets. Bump the package patch version so the signed release can be published from a new tag.

## Scope
- Enable `policy_token` in the release workflow
- Bump plugin package version to `1.4.8`

## Validation
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] Workflow YAML parsed successfully
