### PR TITLE
fix: defer plugin signing until approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
           go-version: '1.25'
           node-version: '24'
           attestation: true
-          policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+          # policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datasource-databend",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Grafana datasource plugin for Databend",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## Problem
The v1.4.8 release failed because enabling `policy_token` attempted to sign the public plugin before Grafana review has granted a signature level. The signing service returned a 409 `InvalidArgument`, so release creation stopped before producing assets.

## Approach
Defer plugin signing by commenting the `policy_token` input again, while keeping provenance attestation enabled. This matches Grafana's public plugin signing flow: submit for review first, then sign after approval grants the plugin signature level.

## Scope
- Disable `policy_token` in the release workflow for now
- Keep `attestation: true` and the required attestation permissions
- Bump plugin package version to `1.4.9`

## Validation
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] Workflow YAML parsed successfully
